### PR TITLE
fix tooltip displayed inside table cell

### DIFF
--- a/source/sass/pandora/_site.scss
+++ b/source/sass/pandora/_site.scss
@@ -389,7 +389,6 @@ body {
     line-height: 1.4;
     -webkit-line-clamp: 3;
     -webkit-box-orient: vertical;
-    overflow: hidden;
     text-overflow: ellipsis;
     padding-left: 0.2em;
     padding-right: 0.2em;
@@ -401,6 +400,10 @@ body {
 	height: 100%;
     width: 9em;
 	font-size: 1em;
+
+	.eu-tooltip {
+		width: 240px;
+	}
 }
 
 .mapping-field-bottom {


### PR DESCRIPTION
Issue Description 
The tooltips don't display properly, ie, when the content of the tooltip is longer/higher than the containing cell the tooltip gets crop inside its cell (as shown in the following screenshot)
![bug2306-tooltip-not-displaying-correctly](https://cloud.githubusercontent.com/assets/5918438/21222518/869350fa-c2c2-11e6-8441-6516b97b500c.png)

After modifying the code the tooltips displays completely even when its content exceeds its containing cell as shown in the following screenshot:
![tooltip-showing-correctly](https://cloud.githubusercontent.com/assets/5918438/21222531/9363cb5c-c2c2-11e6-8fa1-3736e7a5f123.png)
