### PR TITLE
#2494 Footer not sticking to bottom of page when content is not enough

### DIFF
--- a/source/sass/pandora/_homepage-metis.scss
+++ b/source/sass/pandora/_homepage-metis.scss
@@ -1,10 +1,9 @@
-@import "../scss/grid/susy/layout_susy";
+@import '../scss/grid/susy/layout_susy';
 
-/*------------------------------------*\
-  BANNER
-\*------------------------------------*/
+//------------------------------------
+//BANNER
+//------------------------------------
 //included to style banner block on Metis homepage
-
 .header-wrapper .header .cf {
   border-top-color: $eu-jade;
 }
@@ -25,6 +24,15 @@ body {
 
 .metis-main-content {
   margin-top: 4.8rem;
+  // keeping the footer at the bottom even when there is not enough content to push it down.
+  min-height: calc(100vh - 52rem);
+}
+
+@-moz-document url-prefix() {
+  .metis-main-content {
+    // keeping the footer at the bottom even when there is not enough content to push it down.
+    min-height: calc(100vh - 47rem);
+  }
 }
 
 .hero-text {
@@ -51,19 +59,9 @@ body {
   font-weight: bold;
 }
 
-// make styling specific to homepage metis since this might/will affect other sites.
-header.header,
-.site-hero.cf.brand-bottomleft.brand-colour-site,
-section#banner,
-footer.footer.v2{
-  //max-width: 1440px;
-  //margin: 0 auto;
-}
-
 .attribution-content {
   max-width: 300px;
 }
-
 
 // TEMP user icon on Metis homepage required the following styling to be modified accordingly
 @media (min-width: 50em) {
@@ -71,11 +69,13 @@ footer.footer.v2{
     float: right;
   }
 }
+
 .icon {
   &.icon-users {
     display: none;
   }
 }
+
 .fa {
   &.fa-user {
     padding-right: 7px;


### PR DESCRIPTION
When the content in the page is not enough the footer gets push up letting a white space below it. The goal is to force the footer to stay at the bottom of the page.
If the content is long enough the footer should move along with the page and not stay fixed at the bottom blocking the content.